### PR TITLE
Pass enhanced image to cordova, if user preffered it

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-document-scanner",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/NeutrinosPlatform/cordova-plugin-document-scanner"

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-document-scanner"
-        version="3.0.0">
+        version="3.0.1">
 
   <name>Scan</name>
 

--- a/src/ios/Scan.swift
+++ b/src/ios/Scan.swift
@@ -32,7 +32,7 @@ var uri = "";
     }
     
     func imageScannerController(_ scanner: ImageScannerController, didFinishScanningWithResults results: ImageScannerResults) {
-        if(saveImage(image: results.scannedImage)) {
+        if(saveImage(image: results.doesUserPreferEnhancedImage ? (results.enhancedImage ?? results.scannedImage) : results.scannedImage)) {
             let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: uri);
             commandDelegate.send(pluginResult, callbackId:com.callbackId);
         }


### PR DESCRIPTION
**Platform**: iOS (WeScan library)
**Bug**: enhanced image, which appears after pressing "magic wand" button in Review step, is not passed to Cordova
**Solution**: if user presses the "magic wand" button, pass enhanced image to Cordova.