### PR TITLE
Remove line breaks when returning base64 string

### DIFF
--- a/src/android/Scan.java
+++ b/src/android/Scan.java
@@ -119,7 +119,7 @@ public class Scan extends CordovaPlugin {
             bitmap = BitmapFactory.decodeStream(newurl.openConnection().getInputStream());
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream);
-            base64 = Base64.encodeToString(outputStream.toByteArray(), Base64.DEFAULT);
+            base64 = Base64.encodeToString(outputStream.toByteArray(), Base64.NO_WRAP);
         } catch (Exception e) {
             this.callbackContext.error(e.getMessage());
         }


### PR DESCRIPTION
# Description

On android the base64 string was being returned with line breaks in the string, angular will mark the URL as unsafe if it contains line breaks and it won't be displayed. So I've updated the option to return the base64 string without line breaks.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I made the changes to the source and ran the plugin in an ionic-native v4 app using angular and verified that the strings were being returned without line breaks.

# Notes

I spent a lot of time debugging why the URLs were being marked as unsafe and wanted to save others from having to debug this. On iOS the URLs are returned without line breaks so this change also makes the behavior consistent between platforms.