### PR TITLE
iOS: set modalPresentationStyle to fullscreen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-document-scanner",
-  "version": "4.2.5",
+  "version": "4.2.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/NeutrinosPlatform/cordova-plugin-document-scanner"

--- a/src/ios/Scan.m
+++ b/src/ios/Scan.m
@@ -19,6 +19,10 @@
     scanner.showControls = YES;
     scanner.showAutoFocusWhiteRectangle = YES;
 
+    if (@available(iOS 13.0, *)) {
+        scanner.modalPresentationStyle = UIModalPresentationFullScreen;
+    }
+
     [[self topViewController] presentViewController:scanner animated:YES completion:nil];
 }
 


### PR DESCRIPTION
# Description

On iOS version 13 or greater it was possible to dismiss scanner overlay through swiping without getting a cancel response in callback. This causes an unresolved promise and a stuck application.
To prevent this I have reset modalPresentationStyle to fullscreen which was the default setting in iOS12.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Self-tested on real iPhone with iOS 14.5 installed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
